### PR TITLE
Feature/add support py3 [rus]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
 
-    install_requires=['requests', 'beautifulsoup4', 'torrentool', 'lxml'],
+    install_requires=['requests', 'beautifulsoup4', 'torrentool', 'lxml', 'six'],
 
     entry_points={
         'console_scripts': ['torrt = torrt.main:process_commands'],

--- a/torrt/base_tracker.py
+++ b/torrt/base_tracker.py
@@ -1,8 +1,9 @@
 import re
 import logging
+
 from functools import partial
 from itertools import chain
-from urlparse import urlparse, urljoin, parse_qs
+from six.moves.urllib.parse import urlparse, urljoin, parse_qs
 
 import requests
 

--- a/torrt/rpc/deluge.py
+++ b/torrt/rpc/deluge.py
@@ -1,7 +1,12 @@
 import requests
 import logging
 import json
-import base64
+import six
+
+if six.PY3:
+    from base64 import encodebytes as base64encode
+else:
+    from base64 import encodestring as base64encode
 
 from torrt.base_rpc import BaseRPC, TorrtRPCException
 from torrt.utils import RPCClassesRegistry
@@ -93,9 +98,10 @@ class DelugeRPC(BaseRPC):
         return result['torrents']
 
     def method_add_torrent(self, torrent, download_to=None):
+        torrent_dump = base64encode(torrent).decode('utf-8')
         return self.query(
             self.build_request_payload(
-                'webapi.add_torrent', [base64.encodestring(torrent), {'download_location': download_to}]
+                'webapi.add_torrent', [torrent_dump, {'download_location': download_to}]
             )
         )
 

--- a/torrt/rpc/transmission.py
+++ b/torrt/rpc/transmission.py
@@ -1,7 +1,12 @@
 import requests
 import logging
 import json
-import base64
+import six
+
+if six.PY3:
+    from base64 import encodebytes as base64encode
+else:
+    from base64 import encodestring as base64encode
 
 from torrt.base_rpc import BaseRPC, TorrtRPCException
 from torrt.utils import RPCClassesRegistry
@@ -89,7 +94,7 @@ class TransmissionRPC(BaseRPC):
 
     def method_add_torrent(self, torrent, download_to=None):
         args = {
-            'metainfo': base64.encodestring(torrent),
+            'metainfo': base64encode(torrent),
         }
         if download_to is not None:
             args['download-dir'] = download_to

--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -1,7 +1,7 @@
 import requests
 import logging
-from urlparse import urljoin
 
+from six.moves.urllib.parse import urlparse
 from torrt.base_rpc import BaseRPC, TorrtRPCException
 from torrt.utils import RPCClassesRegistry, make_soup
 
@@ -35,7 +35,7 @@ class UTorrentRPC(BaseRPC):
     def login(self):
         try:
             response = requests.get(
-                urljoin(self.url, self.token_page_path),
+                urlparse.urljoin(self.url, self.token_page_path),
                 auth=(self.user, self.password),
                 cookies=self.cookies
             )

--- a/torrt/trackers/rutracker.py
+++ b/torrt/trackers/rutracker.py
@@ -14,6 +14,7 @@ class RuTrackerTracker(GenericPrivateTracker):
     login_url = 'https://%(domain)s/forum/login.php'
     auth_cookie_name = 'bb_session'
     mirrors = ['rutracker.net', 'rutracker.org', 'maintracker.org']
+    encoding = 'cp1251'
 
     def get_id_from_link(self, url):
         """Returns forum thread identifier from full thread URL."""
@@ -21,11 +22,6 @@ class RuTrackerTracker(GenericPrivateTracker):
 
     def get_login_form_data(self, username, password):
         """Returns a dictionary with data to be pushed to authorization form."""
-
-        # convert login and password for fix cyrillic problems
-        username = unicode(username, "utf-8").encode('cp1251')
-        password = unicode(password, "utf-8").encode('cp1251')
-
         return {'login_username': username, 'login_password': password, 'login': 'pushed'}
 
     def before_download(self, url):

--- a/torrt/utils.py
+++ b/torrt/utils.py
@@ -211,6 +211,19 @@ def iter_notifiers():
         yield notifier_alias, notifier_object
 
 
+def encode_value(value, encode=None):
+    """Encode value
+
+    :param value: string
+    :param encode: string - encoding charset
+    :return: string - encoded value
+    """
+    if encode is None:
+        return value
+
+    return unicode(value, "utf-8").encode(encode)
+
+
 class WithSettings(object):
     """Introduces settings support for class objects.
 

--- a/torrt/utils.py
+++ b/torrt/utils.py
@@ -2,6 +2,8 @@ import re
 import os
 import json
 import logging
+import six
+
 from datetime import datetime
 from collections import Mapping
 from pkgutil import iter_modules
@@ -123,7 +125,7 @@ def update_dict(old_dict, new_dict):
     :return: updated dict
     :rtype: dict
     """
-    for key, val in new_dict.iteritems():
+    for key, val in six.iteritems(new_dict):
         if isinstance(val, Mapping):
             old_dict[key] = update_dict(old_dict.get(key, {}), val)
         else:
@@ -221,7 +223,10 @@ def encode_value(value, encode=None):
     if encode is None:
         return value
 
-    return unicode(value, "utf-8").encode(encode)
+    if six.PY2:
+        value = unicode(value, "UTF-8")
+
+    return value.encode(encode)
 
 
 class WithSettings(object):
@@ -293,7 +298,7 @@ class TorrtConfig(object):
             cls.save(cls._basic_settings)
 
         # My precious.
-        os.chmod(cls.USER_SETTINGS_FILE, 0600)
+        os.chmod(cls.USER_SETTINGS_FILE, 0o600)
 
     @classmethod
     def update(cls, settings_dict):


### PR DESCRIPTION
- os.chmod ( http://python-future.org/compatible_idioms.html#octal-constants )
- require six library
- fix unicode problem for py3

Возможно что-то не оптимально сделал
