### PR TITLE
fix unused urlparse in trackers/kinozal [rus]

### DIFF
--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urljoin
 from torrt.base_rpc import BaseRPC, TorrtRPCException
 from torrt.utils import RPCClassesRegistry, make_soup
 
@@ -35,7 +35,7 @@ class UTorrentRPC(BaseRPC):
     def login(self):
         try:
             response = requests.get(
-                urlparse.urljoin(self.url, self.token_page_path),
+                urljoin(self.url, self.token_page_path),
                 auth=(self.user, self.password),
                 cookies=self.cookies
             )

--- a/torrt/trackers/kinozal.py
+++ b/torrt/trackers/kinozal.py
@@ -2,7 +2,6 @@ import logging
 
 from torrt.base_tracker import GenericPrivateTracker
 from torrt.utils import TrackerClassesRegistry
-from urlparse import urlparse, urljoin, parse_qs
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
вылез косяк в py3 исправил
- Remove import urlparse in trackers/kinozal;
- Fix urljoin in rpc/utorrent ( my mistake )