### PR TITLE
added support for Anilibria.tv tracker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Automatic updates are available for:
 * RuTracker (ex torrents.ru) - http://rutracker.org/
 * RUTOR - http://rutor.org/
 * AniDUB - http://tr.anidub.com/
+* AniLibria - https://www.anilibria.tv/
 * NNM-Club - http://nnm-club.me/
 * Kinozal - http://kinozal.tv/
 

--- a/torrt/main.py
+++ b/torrt/main.py
@@ -16,7 +16,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 def process_commands():
-
     def settings_dict_from_list(lst):
         settings_dict = {}
         for s in lst:
@@ -109,6 +108,8 @@ def process_commands():
         help='Registers torrent within torrt by its hash (for torrents already existing at torrent clients)')
     parser_register_torrent.add_argument(
         'hash', help='Torrent identifying hash')
+    parser_register_torrent.add_argument(
+        '-u', dest='url', default=None, help='URL to download torrent from')
 
     parser_unregister_torrent = subp_main.add_parser(
         'unregister_torrent', help='Unregisters torrent from torrt by its hash')
@@ -185,7 +186,7 @@ def process_commands():
         remove_torrent(args['hash'], args['delete_data'])
 
     elif args['command'] == 'register_torrent':
-        register_torrent(args['hash'])
+        register_torrent(args['hash'], url=args['url'])
 
     elif args['command'] == 'unregister_torrent':
         unregister_torrent(args['hash'])

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -160,17 +160,20 @@ def bootstrap():
     init_object_registries()
 
 
-def register_torrent(hash_str, torrent_data=None):
+def register_torrent(hash_str, torrent_data=None, url=None):
     """Registers torrent within torrt. Used to register torrents that already exists
     in torrent clients.
 
     :param hash_str: str - torrent identifying hash
     :param torrent_data: dict
+    :param url: fallback url that will be used in case torrent comment doesn't contain url
     :return:
     """
     LOGGER.debug('Registering `%s` torrent ...', hash_str)
     if torrent_data is None:
         torrent_data = {}
+    if url:
+        torrent_data['url'] = url
     cfg = {'torrents': {}}
     structure_torrent_data(cfg['torrents'], hash_str, torrent_data)
     TorrtConfig.update(cfg)
@@ -207,7 +210,7 @@ def add_torrent_from_url(url, download_to=None):
     else:
         for rpc_alias, rpc_object in iter_rpc():
             rpc_object.method_add_torrent(torrent_data['torrent'], download_to=download_to)
-            register_torrent(torrent_data['hash'], torrent_data)
+            register_torrent(torrent_data['hash'], torrent_data, url)
             LOGGER.info('Torrent from `%s` is added within `%s`', url, rpc_alias)
 
 
@@ -266,11 +269,9 @@ def walk(forced=False, silent=False, remove_outdated=True):
     if forced or now >= next_time:
         LOGGER.info('Torrent walk is started')
 
-        hashes = list(cfg['torrents'].keys())
-
         updated = {}
         try:
-            updated = update_torrents(hashes, remove_outdated=remove_outdated)
+            updated = update_torrents(cfg['torrents'], remove_outdated=remove_outdated)
         except TorrtException as e:
             if not silent:
                 raise
@@ -301,10 +302,10 @@ def walk(forced=False, silent=False, remove_outdated=True):
         )
 
 
-def update_torrents(hashes, remove_outdated=True):
+def update_torrents(to_check, remove_outdated=True):
     """Performs torrent updates.
 
-    :param hashes: list - torrent identifying hashes
+    :param to_check: dict - hash->torrent pairs
     :param remove_outdated: bool - flag to remove outdated torrents from torrent clients
     :return: hash-indexed dictionary with information on updated torrents
     :rtype: dict
@@ -314,7 +315,7 @@ def update_torrents(hashes, remove_outdated=True):
 
     for _, rpc_object in iter_rpc():
         LOGGER.info('Getting torrents from `%s` ...', rpc_object.alias)
-        torrents = rpc_object.method_get_torrents(hashes)
+        torrents = rpc_object.method_get_torrents(list(to_check.keys()))
 
         if not torrents:
             LOGGER.info('  No significant torrents found')
@@ -324,7 +325,10 @@ def update_torrents(hashes, remove_outdated=True):
 
             page_url = get_url_from_string(existing_torrent['comment'])
             if not page_url:
-                LOGGER.warning('    Torrent has no link in comment. Skipped', existing_torrent['name'])
+                page_url = to_check[existing_torrent['hash']].get('url', None)
+
+            if not page_url:
+                LOGGER.warning('    Torrent `%s` has no link in comment. Skipped', existing_torrent['name'])
                 continue
 
             if page_url in download_cache:
@@ -344,6 +348,7 @@ def update_torrents(hashes, remove_outdated=True):
             LOGGER.debug('    Update is available')
             try:
                 rpc_object.method_add_torrent(new_torrent['torrent'], existing_torrent['download_to'])
+                new_torrent['url'] = page_url
                 LOGGER.info('    Torrent is updated')
                 structure_torrent_data(updated_by_hashes, existing_torrent['hash'], new_torrent)
 

--- a/torrt/trackers/anilibria.py
+++ b/torrt/trackers/anilibria.py
@@ -1,0 +1,51 @@
+import logging
+import re
+
+from torrt.base_tracker import GenericPublicTracker
+from torrt.utils import TrackerClassesRegistry
+
+LOGGER = logging.getLogger(__name__)
+
+REGEX_QUALITY = re.compile(ur".+\[(.+)\]")
+
+
+class AnilibriaTracker(GenericPublicTracker):
+    """This class implements .torrent files downloads for https://www.anilibria.tv tracker."""
+
+    alias = 'anilibria.tv'
+
+    def __init__(self, quality_prefs=None):
+        super(AnilibriaTracker, self).__init__()
+        if quality_prefs is None:
+            quality_prefs = ['HDTVRip 1080p', 'HDTVRip 720p', 'WEBRip 720p']
+        self.quality_prefs = quality_prefs
+
+    def get_download_link(self, url):
+        """Tries to find .torrent file download link at forum thread page and return that one."""
+        page_soup = self.get_response(url, as_soup=True)
+
+        available_qualities = {}
+        divs = page_soup.select('div.download-torrent')
+        for div in divs:
+            quality_span = div.select('div.torrent-first-col > span')
+            match = REGEX_QUALITY.search(quality_span[0].text.strip())
+            quality = match.group(1)
+            link = self.expand_link(url, div.select('div.torrent-fourth-col a.torrent-download-link')[0]['href'])
+            available_qualities[quality] = link
+
+        LOGGER.debug('Available in qualities: %s', ', '.join(available_qualities.keys()))
+
+        if available_qualities:
+            preferred_qualities = [quality for quality in self.quality_prefs if quality in available_qualities]
+            if not preferred_qualities:
+                LOGGER.debug('Torrent is not available in preferred qualities: %s', ', '.join(self.quality_prefs))
+            else:
+                target_quality = preferred_qualities[0]
+                LOGGER.debug('Trying to get torrent in `%s` quality ...', target_quality)
+
+                return available_qualities[target_quality]
+
+        return None
+
+
+TrackerClassesRegistry.add(AnilibriaTracker)

--- a/torrt/utils.py
+++ b/torrt/utils.py
@@ -177,7 +177,7 @@ def structure_torrent_data(target_dict, hash_str, data):
 
     :param target_dict: dict - dictionary to update
     :param hash_str: str - torrent identifying hash
-    :param data: dict - torrent data recieved from RPC (see parse_torrent())
+    :param data: dict - torrent data received from RPC (see parse_torrent())
     :return:
     """
     data = dict(data)
@@ -188,9 +188,13 @@ def structure_torrent_data(target_dict, hash_str, data):
     if 'name' not in data:
         data['name'] = None
 
+    if 'url' not in data:
+        data['url'] = None
+
     target_dict[hash_str] = {
         'hash': data['hash'],
-        'name': data['name']
+        'name': data['name'],
+        'url': data['url']
     }
 
 


### PR DESCRIPTION
AniLibria torrent file comments are empty unlike other trackers files. The idea is to pass url as optional parameter with `register_torrent` command run.