### PR TITLE
Restore compatibility with Python 3x, fix '--verbose' flag check

### DIFF
--- a/torrt/main.py
+++ b/torrt/main.py
@@ -126,7 +126,7 @@ def process_commands():
     args = arg_parser.parse_args()
     args = vars(args)
 
-    configure_logging(logging.DEBUG if args['verbose'] else logging.INFO)
+    configure_logging(logging.DEBUG if args.get('verbose') else logging.INFO)
 
     bootstrap()
 

--- a/torrt/trackers/anilibria.py
+++ b/torrt/trackers/anilibria.py
@@ -6,7 +6,7 @@ from torrt.utils import TrackerClassesRegistry
 
 LOGGER = logging.getLogger(__name__)
 
-REGEX_QUALITY = re.compile(ur".+\[(.+)\]")
+REGEX_QUALITY = re.compile(r".+\[(.+)\]")
 
 
 class AnilibriaTracker(GenericPublicTracker):


### PR DESCRIPTION
This PR fixes py3 compatibility that degraded with Anilibra's tracker addition
Also, fixes long known bug with `--verbose` flag check, that crashes app, if run without sub-command 

