### PR TITLE
CasStudio download link was changed.

### DIFF
--- a/torrt/trackers/casstudio.py
+++ b/torrt/trackers/casstudio.py
@@ -18,6 +18,8 @@ class CasstudioTracker(GenericPrivateTracker):
     auth_cookie_name = 'phpbb3_lawmj_sid'
     auth_qs_param_name = 'mode'
 
+    test_urls = ['https://casstudio.tv/viewtopic.php?t=1222']
+
     def get_login_form_data(self, login, password):
         index_page = self.get_response(url=(self.login_url % {'domain': self.alias}))
         soup_response = self.make_page_soup(index_page.text)

--- a/torrt/trackers/casstudio.py
+++ b/torrt/trackers/casstudio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import logging
-
 import six
 
 from torrt.base_tracker import GenericPrivateTracker
@@ -41,7 +41,7 @@ class CasstudioTracker(GenericPrivateTracker):
             page_soup = self.get_response(
                 url, referer=url, cookies=self.cookies, query_string=self.query_string, as_soup=True
             )
-        download_link = self.find_links(url, page_soup, r'\./download/file\.php\?id=\d+$')
+        download_link = self.expand_link(url, page_soup.find('a', text='Скачать торрент')['href'])
         return download_link
 
 


### PR DESCRIPTION
Unfortunately href regex does not working anymore. It was replaced.