### PR TITLE
fix: base64encode for deluge [RUS]

### DIFF
--- a/torrt/rpc/deluge.py
+++ b/torrt/rpc/deluge.py
@@ -92,7 +92,7 @@ class DelugeRPC(BaseRPC):
         return result['torrents']
 
     def method_add_torrent(self, torrent, download_to=None):
-        torrent_dump = base64encode(torrent).decode('utf-8')
+        torrent_dump = base64encode(torrent)
         return self.query(
             self.build_request_payload(
                 'webapi.add_torrent', [torrent_dump, {'download_location': download_to}]


### PR DESCRIPTION
После обновления заметил, что перестали приходить уведомления в телеграм. И как оказалось ловил ошибку:
```
DEBUG: Torrent was downloaded from `......`
DEBUG:     Update is available
Traceback (most recent call last):
  File "/usr/local/bin/torrt", line 11, in <module>
    load_entry_point('torrt==0.11.1', 'console_scripts', 'torrt')()
  File "/usr/local/lib/python3.5/dist-packages/torrt-0.11.1-py3.5.egg/torrt/main.py", line 194, in process_commands
    walk(forced=args['forced'], silent=True)
  File "/usr/local/lib/python3.5/dist-packages/torrt-0.11.1-py3.5.egg/torrt/toolbox.py", line 288, in walk
    updated = update_torrents(cfg['torrents'], remove_outdated=remove_outdated)
  File "/usr/local/lib/python3.5/dist-packages/torrt-0.11.1-py3.5.egg/torrt/toolbox.py", line 389, in update_torrents
    rpc_object.method_add_torrent(new_torrent['torrent'], existing_torrent['download_to'])
  File "/usr/local/lib/python3.5/dist-packages/torrt-0.11.1-py3.5.egg/torrt/rpc/deluge.py", line 95, in method_add_torrent
    torrent_dump = base64encode(torrent).decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```
