### PR TITLE
Preserve user-defined quality priorities

### DIFF
--- a/tests/trackers/test_anilibria.py
+++ b/tests/trackers/test_anilibria.py
@@ -12,3 +12,25 @@ from torrt.trackers.anilibria import AnilibriaTracker
 ])
 def test_sanitize_quantity(test_input, expected):
     assert AnilibriaTracker.sanitize_quality(test_input) == expected
+
+
+def test_get_download_link_preserve_priorities(monkeypatch):
+    """
+    Test that `get_download_link` returns link according user-defined quality priorities
+    """
+
+    # given
+    testable = AnilibriaTracker(quality_prefs=['webrip720p', 'webrip1080p'])
+    expected = 'https://www.anilibria.tv/upload/torrents/webrip720p.torrent'
+
+    def mockreturn(url):
+        return {
+            'webrip1080p': 'https://www.anilibria.tv/upload/torrents/webrip1080p.torrent',
+            'webrip720p': expected,
+        }
+
+    monkeypatch.setattr(testable, "find_available_qualities", mockreturn)
+    # when
+    actual = testable.get_download_link('https://anilibria.tv/release/dummy_release.html')
+    # then
+    assert actual == expected


### PR DESCRIPTION
`{self.sanitize_quality(pref) for pref in self.quality_prefs}` is a set and it is not ordered. As a result torrt frequently picked quality with lower priority but higher-priority quality was available.