### PR TITLE
Made the "base64encode" method version-agnostic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,40 @@
 import pytest
 
+import six
 import torrt.utils as utils
 
 
-def test_base64encode_str():
-    string_to_encode = 'this is string'
-    encoded_string = utils.base64encode(string_to_encode)
+if six.PY3:
 
-    assert isinstance(encoded_string, str)
-    assert encoded_string == "dGhpcyBpcyBzdHJpbmc=\n"
+    def test_base64encode_str():
+        string_to_encode = 'this is string'
+        encoded_bytes = utils.base64encode(string_to_encode)
+
+        assert isinstance(encoded_bytes, bytes)
+        assert encoded_bytes == b'dGhpcyBpcyBzdHJpbmc=\n'
 
 
-def test_base64encode_bytes():
-    bytes_to_encode = b'this is bytes to encode'
-    encoded_string = utils.base64encode(bytes_to_encode)
+    def test_base64encode_bytes():
+        bytes_to_encode = b'this is bytes to encode'
+        encoded_bytes = utils.base64encode(bytes_to_encode)
 
-    assert isinstance(encoded_string, str)
-    assert encoded_string == 'dGhpcyBpcyBieXRlcyB0byBlbmNvZGU=\n'
+        assert isinstance(encoded_bytes, bytes)
+        assert encoded_bytes == b'dGhpcyBpcyBieXRlcyB0byBlbmNvZGU=\n'
+
+
+if six.PY2:
+
+    def test_base64encode_str():
+        string_to_encode = 'this is string'
+        encoded_string = utils.base64encode(string_to_encode)
+
+        assert isinstance(encoded_string, str)
+        assert encoded_string == "dGhpcyBpcyBzdHJpbmc=\n"
+
+
+    def test_base64encode_bytes():
+        bytes_to_encode = b'this is bytes to encode'
+        encoded_string = utils.base64encode(bytes_to_encode)
+
+        assert isinstance(encoded_string, str)
+        assert encoded_string == 'dGhpcyBpcyBieXRlcyB0byBlbmNvZGU=\n'

--- a/torrt/compat.py
+++ b/torrt/compat.py
@@ -47,6 +47,6 @@ else:
         """Return base64 encoded input
 
         :param string_or_bytes:
-        :return: str
+        :return: bytes
         """
         return base64.encodestring(string_or_bytes)

--- a/torrt/compat.py
+++ b/torrt/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Cross-version compatability library
+"""Cross-version compatibility library
 
 This module contains various version-bound function implementations.
 
@@ -34,12 +34,12 @@ if six.PY3:
         """Return base64 encoded input
 
         :param string_or_bytes:
-        :return: str
+        :return: bytes
         """
         if isinstance(string_or_bytes, str):
             string_or_bytes = string_or_bytes.encode('utf-8')
 
-        return base64.encodebytes(string_or_bytes).decode('ascii')
+        return base64.encodebytes(string_or_bytes).decode('ascii').encode('utf-8')
 
 else:
 


### PR DESCRIPTION
Made the "base64encode" method return the same result type (a sequence of bytes) whatever the python version it's run on