### PR TITLE
Replace the way of getting Anilibria .torrent files: Anilibria website -> Anilibria API

### DIFF
--- a/tests/trackers/test_anilibria.py
+++ b/tests/trackers/test_anilibria.py
@@ -4,6 +4,14 @@ from torrt.trackers.anilibria import AnilibriaTracker
 
 
 @pytest.mark.parametrize("test_input,expected", [
+    ('https://www.anilibria.tv/release/kabukichou-sherlock.html', 'kabukichou-sherlock'),
+    ('https://www.anilibria.tv/release/mairimashita-iruma-kun.html', 'mairimashita-iruma-kun'),
+])
+def test_extract_release_code(test_input, expected):
+    assert AnilibriaTracker.extract_release_code(test_input) == expected
+
+
+@pytest.mark.parametrize("test_input,expected", [
     ('WEBRip 1080p', 'webrip1080p'),
     ('WEBRip-1080p', 'webrip1080p'),
     ('WEBRip_1080p', 'webrip1080p'),


### PR DESCRIPTION
Resolve the following problems:
1.  DDOS protection from Anilibria hosting provider
1. https://www.youtube.com/watch?v=pHlYC-aCzek
1. Choose and pick correct .torrent file when TV show is broken into several .torrent files