### PR TITLE
Compare string ranges as numbers

### DIFF
--- a/tests/trackers/test_anilibria.py
+++ b/tests/trackers/test_anilibria.py
@@ -22,6 +22,15 @@ def test_sanitize_quantity(test_input, expected):
     assert AnilibriaTracker.sanitize_quality(test_input) == expected
 
 
+@pytest.mark.parametrize("test_input,expected", [
+    ('1-9', (1, 9)),
+    ('1-10', (1, 10)),
+    ('21-39', (21, 39)),
+])
+def test_to_tuple(test_input, expected):
+    assert AnilibriaTracker.to_tuple(test_input) == expected
+
+
 def test_get_download_link_preserve_priorities(monkeypatch):
     """
     Test that `get_download_link` returns link according user-defined quality priorities

--- a/torrt/trackers/anilibria.py
+++ b/torrt/trackers/anilibria.py
@@ -80,7 +80,7 @@ class AnilibriaTracker(GenericPublicTracker):
                 series2torrents[torrent['series']].append(torrent)
 
         # some releases can be broken into several .torrent files, e.g. 1-20 and 21-41 - take the last one
-        sorted_series = sorted(series2torrents.keys(), reverse=True)
+        sorted_series = sorted(series2torrents.keys(), key=self.to_tuple, reverse=True)
         for torrent in series2torrents[sorted_series[0]]:
             quality = self.sanitize_quality(torrent['quality'])
             available_qualities[quality] = HOST + torrent['url']
@@ -120,6 +120,21 @@ class AnilibriaTracker(GenericPublicTracker):
         if quality_str:
             return REGEX_NON_WORD.sub('', quality_str).lower()
         return ''
+
+    @staticmethod
+    def to_tuple(range_str: str):
+        """
+        Turn passed range_str into tuple of integers.
+        Examples:
+
+        * `to_tuple('1-10')` -> (1, 10)
+
+        :type range_str: str
+        :param range_str: series range string
+        :rtype Tuple[int, int]
+        :return: range as a tuple of integers
+        """
+        return tuple(map(int, range_str.split('-')))
 
 
 TrackerClassesRegistry.add(AnilibriaTracker)


### PR DESCRIPTION
Anilibria has a habit to publish release with highest quality first and forget about  lower quality. And when series number has more digits than the other one then we pick incorrect torrent.
See example:
1-9 [WEBRip 1080p HEVC] - incorrect pick
1-10 [WEBRip 1080p] - correct pick