### PR TITLE
Try to preserve list of unwanted files

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,7 @@ class DummyRPC(BaseRPC):
         self.enabled = enabled
         self.torrents = {}
 
-    def method_add_torrent(self, torrent, download_to=None, excluded_files: List[str] = None):
+    def method_add_torrent(self, torrent, download_to=None, exclude_files: List[str] = None):
         parsed = Torrent.from_string(torrent)
         self.torrents[parsed.info_hash] = parsed
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 from os.path import dirname, realpath, join
+from typing import List
 
 from torrentool.torrent import Torrent
 
@@ -38,7 +39,7 @@ class DummyRPC(BaseRPC):
         self.enabled = enabled
         self.torrents = {}
 
-    def method_add_torrent(self, torrent, download_to=None):
+    def method_add_torrent(self, torrent, download_to=None, excluded_files: List[str] = None):
         parsed = Torrent.from_string(torrent)
         self.torrents[parsed.info_hash] = parsed
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,8 +39,8 @@ class DummyRPC(BaseRPC):
         self.enabled = enabled
         self.torrents = {}
 
-    def method_add_torrent(self, torrent, download_to=None, exclude_files: List[str] = None):
-        parsed = Torrent.from_string(torrent)
+    def method_add_torrent(self, torrent: dict, download_to: str = None, params: dict = None):
+        parsed = Torrent.from_string(torrent['torrent'])
         self.torrents[parsed.info_hash] = parsed
 
     def method_remove_torrent(self, hash_str, with_data=False):

--- a/torrt/base_rpc.py
+++ b/torrt/base_rpc.py
@@ -39,11 +39,12 @@ class BaseRPC(WithSettings):
         """
         raise NotImplementedError  # pragma: nocover
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
         """Adds torrent to torrent client using RPC.
 
         :param torrent: torrent file contents
         :param download_to: path to download files from torrent into (in terms of torrent client filesystem)
+        :param excluded_files: files that should be marked as "not to download"
 
         """
         raise NotImplementedError  # pragma: nocover

--- a/torrt/base_rpc.py
+++ b/torrt/base_rpc.py
@@ -39,12 +39,12 @@ class BaseRPC(WithSettings):
         """
         raise NotImplementedError  # pragma: nocover
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: dict, download_to: str = None, params: dict = None) -> Any:
         """Adds torrent to torrent client using RPC.
 
-        :param torrent: torrent file contents
+        :param torrent: torrent info
         :param download_to: path to download files from torrent into (in terms of torrent client filesystem)
-        :param exclude_files: files that should be marked as "not to download"
+        :param params: optional information attached to torrent that should be saved
 
         """
         raise NotImplementedError  # pragma: nocover

--- a/torrt/base_rpc.py
+++ b/torrt/base_rpc.py
@@ -39,12 +39,12 @@ class BaseRPC(WithSettings):
         """
         raise NotImplementedError  # pragma: nocover
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
         """Adds torrent to torrent client using RPC.
 
         :param torrent: torrent file contents
         :param download_to: path to download files from torrent into (in terms of torrent client filesystem)
-        :param excluded_files: files that should be marked as "not to download"
+        :param exclude_files: files that should be marked as "not to download"
 
         """
         raise NotImplementedError  # pragma: nocover

--- a/torrt/rpc/deluge.py
+++ b/torrt/rpc/deluge.py
@@ -131,7 +131,7 @@ class DelugeRPC(BaseRPC):
 
         return result['torrents']
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
 
         torrent_dump = base64encode(torrent).decode()
 

--- a/torrt/rpc/deluge.py
+++ b/torrt/rpc/deluge.py
@@ -131,9 +131,9 @@ class DelugeRPC(BaseRPC):
 
         return result['torrents']
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: dict, download_to: str = None, params: dict = None) -> Any:
 
-        torrent_dump = base64encode(torrent).decode()
+        torrent_dump = base64encode(torrent['torrent']).decode()
 
         return self.query(
             self.build_request_payload(

--- a/torrt/rpc/deluge.py
+++ b/torrt/rpc/deluge.py
@@ -131,7 +131,7 @@ class DelugeRPC(BaseRPC):
 
         return result['torrents']
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
 
         torrent_dump = base64encode(torrent).decode()
 

--- a/torrt/rpc/qbittorrent.py
+++ b/torrt/rpc/qbittorrent.py
@@ -183,9 +183,9 @@ class QBittorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: dict, download_to: str = None, params: dict = None) -> Any:
 
-        file_data = {'torrents': torrent}
+        file_data = {'torrents': torrent['torrent']}
 
         if download_to is not None:
             file_data.update({'savepath': download_to})

--- a/torrt/rpc/qbittorrent.py
+++ b/torrt/rpc/qbittorrent.py
@@ -183,7 +183,7 @@ class QBittorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
 
         file_data = {'torrents': torrent}
 

--- a/torrt/rpc/qbittorrent.py
+++ b/torrt/rpc/qbittorrent.py
@@ -183,7 +183,7 @@ class QBittorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
 
         file_data = {'torrents': torrent}
 

--- a/torrt/rpc/transmission.py
+++ b/torrt/rpc/transmission.py
@@ -113,16 +113,16 @@ class TransmissionRPC(BaseRPC):
 
         for torrent_info in result['torrents']:
             self.normalize_field_names(torrent_info)
-            torrent_info['excluded_files'] = self.__get_unwanted_files(torrent_info)
+            torrent_info['exclude_files'] = self.__get_unwanted_files(torrent_info)
 
         return result['torrents']
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
         args = {
             'metainfo': base64encode(torrent).decode(),
         }
 
-        if excluded_files:
+        if exclude_files:
             # REVIEW: I don't have good idea on how not to parse torrent again.
             # We can pass list of indices, so we don't need to parse torrent again.
             # But I think list of file names is more generic then list of file indices
@@ -130,7 +130,7 @@ class TransmissionRPC(BaseRPC):
             torrent = parse_torrent(torrent)
             excluded_indices = []
             for i, f in enumerate(torrent['files']):
-                if f in excluded_files:
+                if f in exclude_files:
                     excluded_indices.append(i)
 
             if not excluded_indices:

--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -146,7 +146,7 @@ class UTorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
 
         # NB: `download_to` is ignored, as existing API approach to it is crippled.
         file_data = {'torrent_file': ('from_torrt.torrent', torrent)}

--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -146,7 +146,7 @@ class UTorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None) -> Any:
+    def method_add_torrent(self, torrent: bytes, download_to: str = None, excluded_files: List[str] = None) -> Any:
 
         # NB: `download_to` is ignored, as existing API approach to it is crippled.
         file_data = {'torrent_file': ('from_torrt.torrent', torrent)}

--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -146,10 +146,10 @@ class UTorrentRPC(BaseRPC):
 
         return torrents_info
 
-    def method_add_torrent(self, torrent: bytes, download_to: str = None, exclude_files: List[str] = None) -> Any:
+    def method_add_torrent(self, torrent: dict, download_to: str = None, params: dict = None) -> Any:
 
         # NB: `download_to` is ignored, as existing API approach to it is crippled.
-        file_data = {'torrent_file': ('from_torrt.torrent', torrent)}
+        file_data = {'torrent_file': ('from_torrt.torrent', torrent['torrent'])}
 
         return self.query(self.build_params(action='add-file'), file_data)
 

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -377,7 +377,7 @@ def update_torrents(hashes: Dict[str, dict], remove_outdated: bool = True) -> Di
                 rpc_object.method_add_torrent(
                     new_torrent['torrent'],
                     existing_torrent['download_to'],
-                    excluded_files=existing_torrent.get('excluded_files', None)
+                    exclude_files=existing_torrent.get('exclude_files', None)
                 )
                 new_torrent['url'] = page_url
 

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -210,7 +210,7 @@ def add_torrent_from_url(url: str, download_to: str = None):
     else:
 
         for rpc_alias, rpc_object in iter_rpc():
-            rpc_object.method_add_torrent(torrent_data['torrent'], download_to=download_to)
+            rpc_object.method_add_torrent(torrent_data, download_to=download_to)
             register_torrent(torrent_data['hash'], torrent_data, url)
 
             LOGGER.info('Torrent from `%s` is added within `%s`', url, rpc_alias)
@@ -375,9 +375,9 @@ def update_torrents(hashes: Dict[str, dict], remove_outdated: bool = True) -> Di
 
             try:
                 rpc_object.method_add_torrent(
-                    new_torrent['torrent'],
+                    new_torrent,
                     existing_torrent['download_to'],
-                    exclude_files=existing_torrent.get('exclude_files', None)
+                    params=existing_torrent.get('params', None)
                 )
                 new_torrent['url'] = page_url
 

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -210,7 +210,6 @@ def add_torrent_from_url(url: str, download_to: str = None):
     else:
 
         for rpc_alias, rpc_object in iter_rpc():
-
             rpc_object.method_add_torrent(torrent_data['torrent'], download_to=download_to)
             register_torrent(torrent_data['hash'], torrent_data, url)
 
@@ -375,7 +374,11 @@ def update_torrents(hashes: Dict[str, dict], remove_outdated: bool = True) -> Di
             LOGGER.debug('    Update is available')
 
             try:
-                rpc_object.method_add_torrent(new_torrent['torrent'], existing_torrent['download_to'])
+                rpc_object.method_add_torrent(
+                    new_torrent['torrent'],
+                    existing_torrent['download_to'],
+                    excluded_files=existing_torrent.get('excluded_files', None)
+                )
                 new_torrent['url'] = page_url
 
                 LOGGER.info('    Torrent is updated')


### PR DESCRIPTION
Torrt always recreate a torrent and as a result doesn't preserve list of files that a user marked as "do not download".

* This is a prototype for now. Are you OK to accept the feature?
* This feature is applicable to transmission only. I'm not going to support other RPCs due to lack of API functions.
* The approach is not precise. You cannot be 100% sure that it is the same unwanted file that it was before. Hashes and names can be updated.