### PR TITLE
`add_torrent` command doesn't add torrent if it consists of single ep…

### DIFF
--- a/tests/trackers/test_anilibria.py
+++ b/tests/trackers/test_anilibria.py
@@ -53,9 +53,9 @@ def test_get_download_link_preserve_priorities(monkeypatch):
     assert actual == expected
 
 
-def test_find_available_qualities_handle_no_results(monkeypatch):
+def test_find_available_qualities_handle_first_episode_available(monkeypatch):
     """
-    Test that `find_available_qualities` doesn't fail if there are no acceptable results available.
+    Test that `find_available_qualities` returns single-episode torrent if only the first episode is available.
     """
 
     # given
@@ -90,4 +90,4 @@ def test_find_available_qualities_handle_no_results(monkeypatch):
     # when
     actual = testable.find_available_qualities('https://anilibria.tv/release/dummy_release.html')
     # then
-    assert not actual
+    assert actual == {"webrip1080p": "https://www.anilibria.tv/upload/torrents/11113.torrent"}

--- a/torrt/trackers/anilibria.py
+++ b/torrt/trackers/anilibria.py
@@ -87,9 +87,14 @@ class AnilibriaTracker(GenericPublicTracker):
         available_qualities = {}
         torrents = json['data']['torrents']
         series2torrents = defaultdict(list)
-
+        # a release can consist of several torrents:
+        #   1. episode ranges (different qualities),
+        #   2. single episodes (different qualities) - a release is just aired,
+        #   3. trailers,
+        #   4. OVAs
+        # we are trying to recognize `1` and `2`.
         for torrent in torrents:
-            if REGEX_RANGE.match(torrent['series']):  # filter out single-file torrents like trailers,...
+            if REGEX_RANGE.match(torrent['series']) or torrent['series'] == json['data']['series']:
                 series2torrents[torrent['series']].append(torrent)
 
         # some releases can be broken into several .torrent files, e.g. 1-20 and 21-41 - take the last one


### PR DESCRIPTION
…isode. The problem is related to recently aired TV shows with one episode.