### PR TITLE
Rutracker direct proxies patch

### DIFF
--- a/torrt/base_tracker.py
+++ b/torrt/base_tracker.py
@@ -160,6 +160,7 @@ class BaseTracker(WithSettings):
             allow_redirects: bool = True,
             referer: str = None,
             cookies: Union[dict, CookieJar] = None,
+            proxies: dict = None,
             query_string: str = None,
             as_soup: bool = False
 
@@ -178,6 +179,8 @@ class BaseTracker(WithSettings):
         :param referer: data to put into Referer header
 
         :param cookies: cookies to use
+
+        :param proxies: proxies to specific request
 
         :param query_string:  query string (GET parameters) to add to URL
 
@@ -203,6 +206,7 @@ class BaseTracker(WithSettings):
             referer=referer,
             allow_redirects=allow_redirects,
             cookies=cookies,
+            proxies=proxies,
         )
 
         if result is not None and as_soup:
@@ -314,10 +318,11 @@ class BaseTracker(WithSettings):
         finally:
             setlocale(LC_ALL, old_locale)
 
-    def get_torrent_page(self, url: str, *, drop_cache: bool = False) -> BeautifulSoup:
+    def get_torrent_page(self, url: str, *, proxies: dict = None, drop_cache: bool = False) -> BeautifulSoup:
         """Get torrent page as soup for further data extraction.
 
         :param url:
+        :param proxies: Proxies to use
         :param drop_cache: Do not use cached version if any.
 
         """
@@ -331,6 +336,7 @@ class BaseTracker(WithSettings):
                 url,
                 referer=url,
                 cookies=self.cookies,
+                proxies=proxies,
                 query_string=self.get_query_string(),
                 as_soup=True
             )
@@ -472,7 +478,7 @@ class GenericPrivateTracker(GenericPublicTracker):
     def test_configuration(self) -> bool:
         return self.login(self.alias)
 
-    def login(self, domain: str) -> bool:
+    def login(self, domain: str, proxies: dict = None) -> bool:
         """Implements tracker login procedure. Returns success bool."""
 
         login_url = self.login_url % {'domain': domain}
@@ -502,7 +508,8 @@ class GenericPrivateTracker(GenericPublicTracker):
         response = self.get_response(
             login_url, form_data,
             allow_redirects=allow_redirects,
-            cookies=self.cookies
+            cookies=self.cookies,
+            proxies=proxies,
         )
 
         if not response:  # e.g. Connection aborted.

--- a/torrt/trackers/rutracker.py
+++ b/torrt/trackers/rutracker.py
@@ -28,19 +28,19 @@ class RuTrackerTracker(GenericPrivateTracker):
         """Used to perform some required actions right before .torrent download."""
         self.cookies['bb_dl'] = self.get_id_from_link(url)  # A check that user himself have visited torrent's page ;)
 
-    def get_download_link(self, url: str) -> str:
+    def get_download_link(self, url: str, proxies: dict = None) -> str:
         """Tries to find .torrent file download link at forum thread page and return that one."""
 
-        page_soup = self.get_torrent_page(url)
+        page_soup = self.get_torrent_page(url, proxies=proxies)
 
         domain = self.extract_domain(url)
 
         is_anonymous = self.find_links(url, page_soup, 'register') is not None
 
         if is_anonymous:
-            self.login(domain)
+            self.login(domain, proxies=proxies)
 
-            page_soup = self.get_torrent_page(url, drop_cache=True)
+            page_soup = self.get_torrent_page(url, proxies=proxies, drop_cache=True)
 
         download_link = self.find_links(url, page_soup, r'dl\.php')
 
@@ -58,7 +58,7 @@ class RuTrackerTracker(GenericPrivateTracker):
         except IndexError:
             return
 
-    def download_torrent(self, url: str, referer: str = None) -> Optional[bytes]:
+    def download_torrent(self, url: str, proxies: dict = None, referer: str = None) -> Optional[bytes]:
 
         self.log_debug(f'Downloading torrent file from {url} ...')
 
@@ -75,6 +75,7 @@ class RuTrackerTracker(GenericPrivateTracker):
             url,
             form_data=form_data,
             cookies=self.cookies,
+            proxies=proxies,
             query_string=self.get_query_string(),
             referer=referer,
         )

--- a/torrt/utils.py
+++ b/torrt/utils.py
@@ -69,6 +69,7 @@ class HttpClient:
             allow_redirects: bool = True,
             cookies: dict = None,
             headers: dict = None,
+            proxies: dict = None,
             json: bool = None,
             silence_exceptions: bool = None,
             timeout: int = None,
@@ -82,6 +83,7 @@ class HttpClient:
         :param allow_redirects:
         :param cookies:
         :param headers: Additional headers
+        :param proxies: Proxies to specific request
         :param json: Send and receive data as JSON
         :param silence_exceptions: Do not raise exceptions
         :param timeout: Override timeout.
@@ -103,9 +105,13 @@ class HttpClient:
         if referer:
             headers['Referer'] = referer
 
-        if not self.tunnel:
-            # Drop globally set tunnels settings. See toolbox.tunnel().
-            r_kwargs['proxies'] = {'http': None, 'https': None}
+        # For using proxy exactly in a specific request
+        if not proxies:
+            if not self.tunnel:
+                # Drop globally set tunnels settings. See toolbox.tunnel().
+                r_kwargs['proxies'] = {'http': None, 'https': None}
+        else:
+            r_kwargs['proxies'] = proxies
 
         if json is None:
             json = self.json


### PR DESCRIPTION
Added proxy parameters into several RuTrackerTracker (and deeper) methods.
It might be useful in the case of proxy usage exactly in a specific RuTracker requests.
Tunnel functionality is not affected (can be used both simultaneously).