### PR TITLE
fix trackers rutor get_id_from_link seo link [RUS]

### DIFF
--- a/tests/trackers/test_rutor.py
+++ b/tests/trackers/test_rutor.py
@@ -1,0 +1,16 @@
+from torrt.trackers.rutor import RutorTracker
+
+def test_get_id_from_link():
+    tracker = RutorTracker()
+    tracker.raise_on_error_response = True
+
+    idUrls = {
+        '41': 'http://rutor.info/torrent/41/polnyj-oblom_big-nothing-2006-dvdrip',
+        '472': 'http://rutor.info/torrent/472',
+        '795039': 'http://rutor.info/torrent/795039/vanda/vizhn_wandavision-01h01-03-iz-09-2021-web-dl-720p-lostfilm'
+    }
+
+    for expect_id in idUrls:
+        url = idUrls[expect_id]
+        id = tracker.get_id_from_link(url)
+        assert id == expect_id

--- a/torrt/trackers/rutor.py
+++ b/torrt/trackers/rutor.py
@@ -25,8 +25,9 @@ class RutorTracker(GenericPublicTracker):
         result = splitted[-1]
 
         if not result.isdigit():  # URL contains SEO name in the last chunk
-            result = splitted[-2]
-
+            for result in splitted:
+                if result.isdigit():
+                    break
         return result
 
     def get_download_link(self, url: str) -> str:


### PR DESCRIPTION
неправильно определяется Id торрента, если в SEO урле ( названии торрента ) есть символ "/" ( слеш )

```
url = 'http://rutor.info/torrent/795039/vanda/vizhn_wandavision-01h01-03-iz-09-2021-web-dl-720p-lostfilm'
splitted = url.rstrip('/').split('/')
result = splitted[-1]
if not result.isdigit():  # URL contains SEO name in the last chunk
    result = splitted[-2]
print(result) // vanda, not 795039
```

