### PR TITLE
Fix method_get_torrents on utorrent rpc [RU]

### DIFF
--- a/torrt/rpc/utorrent.py
+++ b/torrt/rpc/utorrent.py
@@ -126,14 +126,15 @@ class UTorrentRPC(BaseRPC):
         torrents_info = []
 
         for torrent_data in result['torrents']:
-            hash_ = torrent_data[0]
+            hash_ = torrent_data[0].lower()
 
             if hashes is None or hash_ in hashes:
 
                 torrents_info.append({
                     'hash': hash_,
                     'name': torrent_data[2],
-                    'download_to': torrent_data[26]
+                    'download_to': torrent_data[26],
+                    'comment': ''
                 })
 
         return torrents_info


### PR DESCRIPTION
1. Поле hash возращается всегда в вверхнем регистре в utorrent;
2. В функции update_torrents нет проверки на наличие comment в rpc_torrent