### PR TITLE
add support for yts.mx tracker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Automatic updates are available for:
 * NNM-Club - http://nnm-club.me/
 * RUTOR - http://rutor.org/
 * RuTracker (ex torrents.ru) - http://rutracker.org/
+* YTS.MX - https://yts.mx/
 
 
 Torrent clients

--- a/tests/trackers/test_ytsmx.py
+++ b/tests/trackers/test_ytsmx.py
@@ -1,0 +1,81 @@
+from typing import Dict
+
+import pytest
+from bs4 import BeautifulSoup
+
+from torrt.trackers.ytsmx import YtsmxTracker
+
+
+@pytest.fixture()
+def tracker():
+    return YtsmxTracker()
+
+
+@pytest.fixture(scope="module")
+def stub_links():
+    return {
+        "720P.WEB": "720p_torrent.link",
+        "1080P.WEB": "1080p_torrent.link",
+    }
+
+
+@pytest.mark.parametrize("given,expected", [
+    ({"type": "web", "quality": "720p"}, "720P.WEB"),
+    ({"type": "web", "quality": "1080p"}, "1080P.WEB"),
+])
+def test_quality_from_torrent(given: Dict[str, str], expected: str):
+    assert YtsmxTracker._get_quality_from_torrent(given) == expected
+
+
+@pytest.mark.parametrize("given,expected", [
+    ("    720P.web", "720P.WEB"),
+    ("1080p.wEb    ", "1080P.WEB"),
+])
+def test_sanitize_config_quality(given: str, expected: str):
+    assert YtsmxTracker._sanitize_quality(given) == expected
+
+
+def test_extract_movie_id(tracker: YtsmxTracker):
+    stub_html = '''
+    <!DOCTYPE html><html>
+    <head></head>
+    <body><div id="movie-info" data-movie-id="123"></body></html>
+    '''
+    soup = BeautifulSoup(stub_html)
+
+    movie_id = tracker._extract_movie_id(soup)
+    assert movie_id == "123"
+
+
+def test_quality_links(tracker: YtsmxTracker):
+    stub_details = {
+        "data": {
+            "movie": {
+                "torrents": [
+                    {
+                        "quality": "720p",
+                        "type": "web",
+                        "url": "http://example.com/torrent.file"
+                    }
+                ]
+            }
+        }
+    }
+    links = tracker._get_quality_links(stub_details)
+    items = list(links.items())
+    assert len(items) == 1
+
+    key, link = items[0]
+    assert key == "720P.WEB"
+    assert link == "http://example.com/torrent.file"
+
+
+@pytest.mark.parametrize("preffered, expected", [
+    (["1080P.WEB", "720P.WEB"], ("1080P.WEB", "1080p_torrent.link")),
+    (["720P.WEB", "1080P.WEB"], ("720P.WEB", "720p_torrent.link")),
+    (["8K.HDTV", "4K.WEB", "2K,HDTV"], None),
+    ([], None),
+])
+def test_preffered_quality(preffered, expected, stub_links):
+    tracker = YtsmxTracker(quality_prefs=preffered)
+    assert tracker._get_preffered_link(stub_links) == expected

--- a/tests/trackers/test_ytsmx.py
+++ b/tests/trackers/test_ytsmx.py
@@ -11,25 +11,25 @@ def tracker():
     return YtsmxTracker()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def stub_links():
     return {
-        "720P.WEB": "720p_torrent.link",
-        "1080P.WEB": "1080p_torrent.link",
+        '720P.WEB': '720p_torrent.link',
+        '1080P.WEB': '1080p_torrent.link',
     }
 
 
-@pytest.mark.parametrize("given,expected", [
-    ({"type": "web", "quality": "720p"}, "720P.WEB"),
-    ({"type": "web", "quality": "1080p"}, "1080P.WEB"),
+@pytest.mark.parametrize('given,expected', [
+    ({'type': 'web', 'quality': '720p'}, '720P.WEB'),
+    ({'type': 'web', 'quality': '1080p'}, '1080P.WEB'),
 ])
 def test_quality_from_torrent(given: Dict[str, str], expected: str):
     assert YtsmxTracker._get_quality_from_torrent(given) == expected
 
 
-@pytest.mark.parametrize("given,expected", [
-    ("    720P.web", "720P.WEB"),
-    ("1080p.wEb    ", "1080P.WEB"),
+@pytest.mark.parametrize('given,expected', [
+    ('    720P.web', '720P.WEB'),
+    ('1080p.wEb    ', '1080P.WEB'),
 ])
 def test_sanitize_config_quality(given: str, expected: str):
     assert YtsmxTracker._sanitize_quality(given) == expected
@@ -44,18 +44,18 @@ def test_extract_movie_id(tracker: YtsmxTracker):
     soup = BeautifulSoup(stub_html)
 
     movie_id = tracker._extract_movie_id(soup)
-    assert movie_id == "123"
+    assert movie_id == '123'
 
 
 def test_quality_links(tracker: YtsmxTracker):
     stub_details = {
-        "data": {
-            "movie": {
-                "torrents": [
+        'data': {
+            'movie': {
+                'torrents': [
                     {
-                        "quality": "720p",
-                        "type": "web",
-                        "url": "http://example.com/torrent.file"
+                        'quality': '720p',
+                        'type': 'web',
+                        'url': 'http://example.com/torrent.file'
                     }
                 ]
             }
@@ -66,14 +66,14 @@ def test_quality_links(tracker: YtsmxTracker):
     assert len(items) == 1
 
     key, link = items[0]
-    assert key == "720P.WEB"
-    assert link == "http://example.com/torrent.file"
+    assert key == '720P.WEB'
+    assert link == 'http://example.com/torrent.file'
 
 
-@pytest.mark.parametrize("preffered, expected", [
-    (["1080P.WEB", "720P.WEB"], ("1080P.WEB", "1080p_torrent.link")),
-    (["720P.WEB", "1080P.WEB"], ("720P.WEB", "720p_torrent.link")),
-    (["8K.HDTV", "4K.WEB", "2K,HDTV"], None),
+@pytest.mark.parametrize('preffered, expected', [
+    (['1080P.WEB', '720P.WEB'], ('1080P.WEB', '1080p_torrent.link')),
+    (['720P.WEB', '1080P.WEB'], ('720P.WEB', '720p_torrent.link')),
+    (['8K.HDTV', '4K.WEB', '2K,HDTV'], None),
     ([], None),
 ])
 def test_preffered_quality(preffered, expected, stub_links):

--- a/torrt/trackers/ytsmx.py
+++ b/torrt/trackers/ytsmx.py
@@ -8,7 +8,7 @@ from ..exceptions import TorrtTrackerException
 from ..base_tracker import GenericPublicTracker
 
 
-API_BASE = "https://yts.mx/api/v2/"
+API_BASE = 'https://yts.mx/api/v2/'
 QualityLinks = Dict[str, str]
 QualityLink = Tuple[str, str]
 
@@ -51,7 +51,7 @@ class YtsmxTracker(GenericPublicTracker):
 
         soup = self.get_torrent_page(url)
         if not soup:
-            raise YtsmxTrackerException("main torrent page loading failed")
+            raise YtsmxTrackerException('main torrent page loading failed')
 
         return soup
 
@@ -72,7 +72,7 @@ class YtsmxTracker(GenericPublicTracker):
     def _get_movie_details(self, movie_id: str) -> dict:
         """returns dict with movie info by calling API"""
 
-        response = self.get_response(API_BASE + f"movie_details.json?movie_id={movie_id}")
+        response = self.get_response(f'{API_BASE}movie_details.json?movie_id={movie_id}')
         if not response:
             raise YtsmxTrackerException("API didn't respond")
 
@@ -90,7 +90,7 @@ class YtsmxTracker(GenericPublicTracker):
                 for torrent in movie_details['data']['movie']['torrents']
             }
         except KeyError:
-            raise YtsmxTrackerException("API movie details response is not parser. API changed")
+            raise YtsmxTrackerException('API movie details response is not parser. API changed')
 
         return qualities
 
@@ -135,7 +135,7 @@ class YtsmxTracker(GenericPublicTracker):
         else:
             self.log_info(
                 'Torrent is not available in preferred qualities: '
-                f"{', '.join(self.quality_prefs)}" or "(empty)"
+                f"{', '.join(self.quality_prefs)}" or '(empty)'
             )
 
             quality, link = next(iter(available_qualities.items()))

--- a/torrt/trackers/ytsmx.py
+++ b/torrt/trackers/ytsmx.py
@@ -1,0 +1,146 @@
+from typing import List, Dict, Tuple, Optional
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from requests.models import Response
+
+from ..exceptions import TorrtTrackerException
+from ..base_tracker import GenericPublicTracker
+
+
+API_BASE = "https://yts.mx/api/v2/"
+QualityLinks = Dict[str, str]
+QualityLink = Tuple[str, str]
+
+class YtsmxTrackerException(TorrtTrackerException):
+    """Yts.mx specific exceptions"""
+
+class YtsmxTracker(GenericPublicTracker):
+    """This class implements .torrent files downloads for https://yts.mx tracker."""
+
+    alias: str = 'yts.mx'
+
+    test_urls: List[str] = [
+        'https://yts.mx/movies/the-matrix-resurrections-2021',
+    ]
+
+    def __init__(self, quality_prefs: List[str] = None):
+        super().__init__()
+
+        if quality_prefs is None:
+            quality_prefs = ['1080P.WEB', '720P.WEB']
+        else:
+            quality_prefs = [self._sanitize_quality(x) for x in quality_prefs]
+
+        self.quality_prefs = quality_prefs
+
+    @staticmethod
+    def _sanitize_quality(q: str) -> str:
+        """sanitizes quality provided by configuration"""
+
+        return q.strip().upper()
+
+    @staticmethod
+    def _get_quality_from_torrent(torrent: dict) -> str:
+        """returns sanitized quality string from API's torrent dict"""
+
+        return f"{torrent['quality']}.{torrent['type']}".upper()
+
+    def _get_torrent_page(self, url: str) -> BeautifulSoup:
+        """loads and parses main torrent's page"""
+
+        soup = self.get_torrent_page(url)
+        if not soup:
+            raise YtsmxTrackerException("main torrent page loading failed")
+
+        return soup
+
+    def _extract_movie_id(self, root: BeautifulSoup) -> str:
+        """returns movie id from tracker's info page"""
+
+        movie_info_tag = root.find("div", {"id": "movie-info"})
+        if not movie_info_tag:
+            raise YtsmxTrackerException("div#movie-info not found on page")
+
+        movie_info_tag: Tag
+        movie_id = movie_info_tag.attrs['data-movie-id']
+        if not movie_id.isdigit():
+            raise YtsmxTrackerException("movie-id is not a digit. Markup is changed")
+
+        return movie_id
+
+    def _get_movie_details(self, movie_id: str) -> dict:
+        """returns dict with movie info by calling API"""
+
+        response = self.get_response(API_BASE + f"movie_details.json?movie_id={movie_id}")
+        if not response:
+            raise YtsmxTrackerException("API didn't respond")
+
+        response: Response
+        movie_info_json = response.json()
+
+        return movie_info_json
+
+    def _get_quality_links(self, movie_details: dict) -> QualityLinks:
+        """extract quality and it's link from API response"""
+
+        try:
+            qualities = {
+                self._get_quality_from_torrent(torrent): torrent['url']
+                for torrent in movie_details['data']['movie']['torrents']
+            }
+        except KeyError:
+            raise YtsmxTrackerException("API movie details response is not parser. API changed")
+
+        return qualities
+
+    def _get_preffered_link(self, links: QualityLinks) -> Optional[QualityLink]:
+        """returns most preffered `QualityLink` of all `links` or `None`"""
+
+        preferred_qualities = [q for q in self.quality_prefs if q in links]
+        if preferred_qualities:
+            quality = preferred_qualities[0]
+            link = links[quality]
+            return quality, link
+
+        return None
+
+    def get_download_link(self, url: str) -> str:
+        """Tries to find .torrent file download link at forum thread page and return that one."""
+
+        try:
+            # 1. load movie page, cache it
+            soup = self._get_torrent_page(url)
+
+            # 2. find movie ID - (eg. 38698)
+            movie_id = self._extract_movie_id(soup)
+
+            # 3. ask the API for details
+            movie_details = self._get_movie_details(movie_id)
+
+            # 4. parse torrent details to find preffered quality
+            available_qualities = self._get_quality_links(movie_details)
+
+        except YtsmxTrackerException as e:
+            self.log_error(str(e))
+            return ''
+
+        self.log_debug(f"Available in qualities: {', '.join(available_qualities)}")
+
+        pref_link = self._get_preffered_link(available_qualities)
+        if pref_link:
+            _, link = pref_link
+            return link
+
+        else:
+            self.log_info(
+                'Torrent is not available in preferred qualities: '
+                f"{', '.join(self.quality_prefs)}" or "(empty)"
+            )
+
+            quality, link = next(iter(available_qualities.items()))
+            self.log_info(f'Fallback to `{quality}` quality ...')
+
+            return link
+
+        return ''

--- a/torrt/trackers/ytsmx.py
+++ b/torrt/trackers/ytsmx.py
@@ -60,12 +60,12 @@ class YtsmxTracker(GenericPublicTracker):
 
         movie_info_tag = root.find("div", {"id": "movie-info"})
         if not movie_info_tag:
-            raise YtsmxTrackerException("div#movie-info not found on page")
+            raise YtsmxTrackerException('div#movie-info not found on page')
 
         movie_info_tag: Tag
         movie_id = movie_info_tag.attrs['data-movie-id']
         if not movie_id.isdigit():
-            raise YtsmxTrackerException("movie-id is not a digit. Markup is changed")
+            raise YtsmxTrackerException('movie-id is not a digit. Markup is changed')
 
         return movie_id
 


### PR DESCRIPTION
obviously, adds support for "yts.mx" tracker.

(I personally see no use in adding this tracker, as there are basically no 'updates' as in other forum-based ones, other than adding torrents from this tracker via Telegram bot. But adding it anyway)

Should satisfy #66 