### PR TITLE
Added non-zero exit code to run_bots if there is no bots to actually run

### DIFF
--- a/torrt/base_bot.py
+++ b/torrt/base_bot.py
@@ -1,3 +1,4 @@
+from .exceptions import TorrtBotException
 from .utils import WithSettings, BotObjectsRegistry, BotClassesRegistry
 
 
@@ -20,3 +21,11 @@ class BaseBot(WithSettings):
 
     def run(self):
         """Run bot to receive incoming commands."""
+
+class BotRegistrationFailed(TorrtBotException):
+
+    """Bot is failed to register (missing dependency or precondition)
+
+    This exception must be raised during bot class construction
+
+    """

--- a/torrt/bots/telegram_bot.py
+++ b/torrt/bots/telegram_bot.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ..base_bot import BaseBot
+from ..base_bot import BaseBot, BotRegistrationFailed
 from ..toolbox import add_torrent_from_url, get_registered_torrents, remove_torrent
 from ..utils import get_torrent_from_url, RPCObjectsRegistry
 
@@ -34,8 +34,7 @@ class TelegramBot(BaseBot):
         self.allowed_users = allowed_users or ''
 
         if not telegram:
-            self.log_error('You have not installed python-telegram-bot library.')
-            return
+            raise BotRegistrationFailed("You have not installed python-telegram-bot library.")
 
         self.handler_kwargs = {}
         self.updater = Updater(token=self.token)

--- a/torrt/exceptions.py
+++ b/torrt/exceptions.py
@@ -20,3 +20,11 @@ class TorrtRPCException(TorrtException):
     All other RPC related exception should inherit from that.
 
     """
+
+
+class TorrtBotException(TorrtException):
+    """Base torrt bot exception
+
+    All other bot related exception should inherit from that.
+
+    """

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -1,7 +1,9 @@
 import logging
+import sys
 from time import time
 from typing import Optional, List, Dict
 
+from .base_bot import BotRegistrationFailed
 from .base_tracker import GenericPrivateTracker
 from .exceptions import TorrtException, TorrtRPCException
 from .utils import (
@@ -142,7 +144,6 @@ def init_object_registries():
     settings_to_registry_map = {
         'rpc': RPCClassesRegistry,
         'notifiers': NotifierClassesRegistry,
-        'bots': BotClassesRegistry,
     }
 
     for settings_entry, registry_cls in settings_to_registry_map.items():
@@ -150,6 +151,19 @@ def init_object_registries():
         for alias, settings in cfg[settings_entry].items():
             registry_obj = registry_cls.get(alias)
             registry_obj and registry_obj.spawn_with_settings(settings).register()
+
+    # Special treatment for bots, as they may require additional dependencies
+    for alias, settings in cfg['bots'].items():
+        registry_obj = BotClassesRegistry.get(alias)
+
+        try:
+            bot_obj = registry_obj.spawn_with_settings(settings)
+
+        except BotRegistrationFailed as e:
+            LOGGER.warn(f'`{alias}` bot is configured, but failed to register: {e}')
+
+        else:
+            bot_obj.register()
 
     # Special case for trackers to initialize public trackers automatically.
     for alias, tracker_cls in TrackerClassesRegistry.get().items():
@@ -435,3 +449,7 @@ def run_bots(aliases: List[str] = None):
             continue
 
         bot_object.run()
+
+    else:
+        # if there is no bots to run - just exit
+        sys.exit(1)


### PR DESCRIPTION
Nice addition to #76 

this way, `systemd` service status will show whether there is something wrong with bots on start