### PR TITLE
Added non-zero exit code to run_bots if there is no bots to actually run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from importlib import import_module
-
 import pytest
 
 from torrt.toolbox import bootstrap
@@ -40,29 +38,3 @@ def mock_config(monkeypatch):
     monkeypatch.setattr('torrt.utils.TorrtConfig', MockConfig)
 
     return settings
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "skip_no_module(module, reason): mark test to run only with this module installed"
-    )
-
-@pytest.fixture(autouse=True)
-def skip_without_module(request):
-    """global fixture, that automatically skips tests marked with
-
-    `@pytest.mark.skip_no_module(module: str, reason: Optional[str] = '')`
-
-    if the requested `module` is unable to be imported
-
-    """
-
-    marker = request.node.get_closest_marker('skip_no_module')
-    if marker:
-        modulename = marker.args[0]
-        reason = marker.args[1] if len(marker.args) > 1 else ''
-
-        try:
-            import_module(modulename)
-        except ImportError:
-            pytest.skip(f"skipped without module: {modulename} {reason}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+
 import pytest
 
 from torrt.toolbox import bootstrap
@@ -38,3 +40,29 @@ def mock_config(monkeypatch):
     monkeypatch.setattr('torrt.utils.TorrtConfig', MockConfig)
 
     return settings
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "skip_no_module(module, reason): mark test to run only with this module installed"
+    )
+
+@pytest.fixture(autouse=True)
+def skip_without_module(request):
+    """global fixture, that automatically skips tests marked with
+
+    `@pytest.mark.skip_no_module(module: str, reason: Optional[str] = '')`
+
+    if the requested `module` is unable to be imported
+
+    """
+
+    marker = request.node.get_closest_marker('skip_no_module')
+    if marker:
+        modulename = marker.args[0]
+        reason = marker.args[1] if len(marker.args) > 1 else ''
+
+        try:
+            import_module(modulename)
+        except ImportError:
+            pytest.skip(f"skipped without module: {modulename} {reason}")

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock
 
 from torrt.toolbox import *
@@ -24,9 +23,15 @@ def test_configure_logging():
     configure_logging(show_logger_names=True)
 
 
-@pytest.mark.skip_no_module("telegram", 'python-telegram-bot not installed')
-def test_bot_telegram(mock_config, monkeypatch):
-    monkeypatch.setattr('torrt.bots.telegram_bot.Updater', MagicMock(), raising=False)
+def test_bots(mock_config, monkeypatch):
+    # mainly mocking everything bot-library-related
+    for target in (
+        'telegram',
+        'ReplyKeyboardMarkup', 'ReplyKeyboardRemove', 'InlineKeyboardMarkup', 'InlineKeyboardButton', 'Bot', 'Update', 'Updater',
+        'Filters', 'Updater', 'ConversationHandler', 'CommandHandler', 'MessageHandler', 'RegexHandler', 'CallbackQueryHandler'
+    ):
+        monkeypatch.setattr(f'torrt.bots.telegram_bot.{target}', MagicMock(), raising=False)
+
     monkeypatch.setattr('torrt.bots.telegram_bot.TelegramBot.test_configuration', lambda *args: True)
 
     bot = configure_bot('telegram', {'token': 'xxx'})

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock
 
 from torrt.toolbox import *
@@ -23,12 +24,14 @@ def test_configure_logging():
     configure_logging(show_logger_names=True)
 
 
-def test_bots(mock_config, monkeypatch):
-
+@pytest.mark.skip_no_module("telegram", 'python-telegram-bot not installed')
+def test_bot_telegram(mock_config, monkeypatch):
     monkeypatch.setattr('torrt.bots.telegram_bot.Updater', MagicMock(), raising=False)
     monkeypatch.setattr('torrt.bots.telegram_bot.TelegramBot.test_configuration', lambda *args: True)
 
-    configure_bot('telegram', {'token': 'xxx'})
+    bot = configure_bot('telegram', {'token': 'xxx'})
+    bot.register()
+
     assert mock_config['bots']['telegram']
 
     run_bots(['telegram'])

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -8,12 +8,26 @@ from torrt.utils import BotObjectsRegistry
 
 @pytest.fixture(scope='function', autouse=True)
 def clear_bot_registry():
-    '''HACK: clears all registered bots before each test.
+    """HACK: clears all registered bots before each test.
 
     otherwise test order matters
-    '''
+    """
 
     BotObjectsRegistry._items.clear()
+
+
+@pytest.fixture(scope='function')
+def mock_telegram_plugin(monkeypatch):
+    """MagicMock'ing everything under `telegram_bot` that's `python-telegram`-related"""
+
+    for target in (
+        'telegram',
+        'ReplyKeyboardMarkup', 'ReplyKeyboardRemove', 'InlineKeyboardMarkup', 'InlineKeyboardButton', 'Update',
+        'Filters', 'Updater', 'ConversationHandler', 'CommandHandler', 'MessageHandler', 'CallbackContext', 'CallbackQueryHandler'
+    ):
+        monkeypatch.setattr(f'torrt.bots.telegram_bot.{target}', MagicMock(), raising=False)
+
+    # yield
 
 
 def test_register_unregister_torrent(mock_config):
@@ -36,15 +50,7 @@ def test_configure_logging():
     configure_logging(show_logger_names=True)
 
 
-def test_bots(mock_config, monkeypatch):
-    # mainly mocking everything bot-library-related
-    for target in (
-        'telegram',
-        'ReplyKeyboardMarkup', 'ReplyKeyboardRemove', 'InlineKeyboardMarkup', 'InlineKeyboardButton', 'Bot', 'Update', 'Updater',
-        'Filters', 'Updater', 'ConversationHandler', 'CommandHandler', 'MessageHandler', 'RegexHandler', 'CallbackQueryHandler'
-    ):
-        monkeypatch.setattr(f'torrt.bots.telegram_bot.{target}', MagicMock(), raising=False)
-
+def test_bots(mock_config, monkeypatch, mock_telegram_plugin):
     monkeypatch.setattr('torrt.bots.telegram_bot.TelegramBot.test_configuration', lambda *args: True)
 
     bot = configure_bot('telegram', {'token': 'xxx'})
@@ -72,6 +78,24 @@ def test_telegram_without_plugin_raises_exception(monkeypatch):
         configure_bot('telegram', {'token': 'xxx'})
 
     assert 'python-telegram-bot' in str(excinfo.value)
+
+
+def test_bot_configured_but_unregistered(monkeypatch, mock_telegram_plugin):
+    # configuring 'mocked' bot just to get it's configuration
+    monkeypatch.setattr(f'torrt.bots.telegram_bot.TelegramBot.test_configuration', lambda *args: True)
+    configure_bot('telegram', {'token': 'xxx'})
+
+    # making bot unspawnable, by forcebly removing required plugin mock
+    monkeypatch.setattr(f'torrt.bots.telegram_bot.telegram', None)
+
+    # check that user get's warning about configured, but unregistered bot
+    mocked_logger = MagicMock()
+    with monkeypatch.context() as m:
+        m.setattr(f'torrt.toolbox.LOGGER', mocked_logger)
+        init_object_registries()
+
+    mocked_logger.warn.assert_called_once()
+    assert 'bot is configured, but failed to register' in mocked_logger.warn.call_args[0][0]
 
 
 def test_notifiers(mock_config, monkeypatch):

--- a/torrt/base_bot.py
+++ b/torrt/base_bot.py
@@ -1,3 +1,4 @@
+from .exceptions import TorrtBotException
 from .utils import WithSettings, BotObjectsRegistry, BotClassesRegistry
 
 
@@ -20,3 +21,11 @@ class BaseBot(WithSettings):
 
     def run(self):
         """Run bot to receive incoming commands."""
+
+class BotRegistrationFailed(TorrtBotException):
+
+    """Bot is failed to register (missing dependency or precondition)
+
+    This exception must be raised during bot class construction
+
+    """

--- a/torrt/bots/telegram_bot.py
+++ b/torrt/bots/telegram_bot.py
@@ -34,7 +34,7 @@ class TelegramBot(BaseBot):
         self.allowed_users = allowed_users or ''
 
         if not telegram:
-            raise BotRegistrationFailed("You have not installed python-telegram-bot library.")
+            raise BotRegistrationFailed('You have not installed python-telegram-bot library.')
 
         self.handler_kwargs = {}
         self.updater = Updater(token=self.token)

--- a/torrt/bots/telegram_bot.py
+++ b/torrt/bots/telegram_bot.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ..base_bot import BaseBot
+from ..base_bot import BaseBot, BotRegistrationFailed
 from ..toolbox import add_torrent_from_url, get_registered_torrents, remove_torrent
 from ..utils import get_torrent_from_url, RPCObjectsRegistry
 
@@ -34,8 +34,7 @@ class TelegramBot(BaseBot):
         self.allowed_users = allowed_users or ''
 
         if not telegram:
-            self.log_error('You have not installed python-telegram-bot library.')
-            return
+            raise BotRegistrationFailed("You have not installed python-telegram-bot library.")
 
         self.handler_kwargs = {}
         self.updater = Updater(token=self.token)

--- a/torrt/exceptions.py
+++ b/torrt/exceptions.py
@@ -20,3 +20,11 @@ class TorrtRPCException(TorrtException):
     All other RPC related exception should inherit from that.
 
     """
+
+
+class TorrtBotException(TorrtException):
+    """Base torrt bot exception
+
+    All other bot related exception should inherit from that.
+
+    """

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -442,14 +442,16 @@ def run_bots(aliases: List[str] = None):
 
     """
     aliases = aliases or []
+    bot_hit = False
 
     for alias, bot_object in iter_bots():
+        bot_hit = True
 
         if aliases and alias not in aliases:
             continue
 
         bot_object.run()
 
-    else:
+    if not bot_hit:
         # if there is no bots to run - just exit
         sys.exit(1)

--- a/torrt/toolbox.py
+++ b/torrt/toolbox.py
@@ -1,7 +1,9 @@
 import logging
+import sys
 from time import time
 from typing import Optional, List, Dict
 
+from .base_bot import BotRegistrationFailed
 from .base_tracker import GenericPrivateTracker
 from .exceptions import TorrtException, TorrtRPCException
 from .utils import (
@@ -142,7 +144,6 @@ def init_object_registries():
     settings_to_registry_map = {
         'rpc': RPCClassesRegistry,
         'notifiers': NotifierClassesRegistry,
-        'bots': BotClassesRegistry,
     }
 
     for settings_entry, registry_cls in settings_to_registry_map.items():
@@ -150,6 +151,19 @@ def init_object_registries():
         for alias, settings in cfg[settings_entry].items():
             registry_obj = registry_cls.get(alias)
             registry_obj and registry_obj.spawn_with_settings(settings).register()
+
+    # Special treatment for bots, as they may require additional dependencies
+    for alias, settings in cfg['bots'].items():
+        registry_obj = BotClassesRegistry.get(alias)
+
+        try:
+            bot_obj = registry_obj.spawn_with_settings(settings)
+
+        except BotRegistrationFailed as e:
+            LOGGER.warn(f'`{alias}` bot is configured, but failed to register: {e}')
+
+        else:
+            bot_obj.register()
 
     # Special case for trackers to initialize public trackers automatically.
     for alias, tracker_cls in TrackerClassesRegistry.get().items():
@@ -435,3 +449,7 @@ def run_bots(aliases: List[str] = None):
             continue
 
         bot_object.run()
+
+    else:
+        # if there is no bots to run - just exit
+        sys.exit(1)


### PR DESCRIPTION
Nice addition to #76

- bot registration now raises `BotRegistrationFailed` if there are dependencies missing.
- at launch, the user can see all the configured bots that failed to register as log warning
- `run_bots` now exits with code 1 if were were no actual bots to run. this way `systemd` (or `supervisord`) status will show whether there is something wrong with bots on the start
- ~~renamed `test_bots` to `test_bot_telegram` and made it conditional on the required package. this helps to pass tests on build servers without installing additional dependencies.~~

(duplicate of #77, as for some reason it didn't pull latest commit)