### PR TITLE
fix yts.mx tracker tests

### DIFF
--- a/tests/trackers/test_ytsmx.py
+++ b/tests/trackers/test_ytsmx.py
@@ -41,7 +41,7 @@ def test_extract_movie_id(tracker: YtsmxTracker):
     <head></head>
     <body><div id="movie-info" data-movie-id="123"></body></html>
     '''
-    soup = BeautifulSoup(stub_html)
+    soup = BeautifulSoup(stub_html, features="lxml")
 
     movie_id = tracker._extract_movie_id(soup)
     assert movie_id == '123'

--- a/torrt/trackers/ytsmx.py
+++ b/torrt/trackers/ytsmx.py
@@ -21,7 +21,7 @@ class YtsmxTracker(GenericPublicTracker):
     alias: str = 'yts.mx'
 
     test_urls: List[str] = [
-        'https://yts.mx/movies/the-matrix-resurrections-2021',
+        'https://yts.mx/movies/the-matrix-1999',
     ]
 
     def __init__(self, quality_prefs: List[str] = None):


### PR DESCRIPTION
Didn't find any public domain movies on that tracker, so resorted to good old Matrix`91.
Also fixed BS4 warning in the same tracker test

Closes #79