### PR TITLE
Housekeeping 2022

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2021, Igor `idle sign` Starikov
+Copyright (c) 2014-2022, Igor `idle sign` Starikov
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'torrt'
-copyright = u'2014-2021, Igor `idle sign` Starikov'
+copyright = u'2014-2022, Igor `idle sign` Starikov'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,7 +62,7 @@ Bots
 Requirements
 ------------
 
-1. Python 3.6+
+1. Python 3.7+
 2. ``deluge-webapi`` plugin (to work with Deluge)
 3. ``python-telegram-bot`` (to run Telegram bot)
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     tests_require=[
         'pytest',
         'pytest-datafixtures',
-        'pytest-responsemock>=1.0.0',
+        'pytest-responsemock>=1.1.0',
     ],
 
     entry_points={
@@ -67,7 +67,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # See http://tox.readthedocs.org/en/latest/examples.html for samples.
 
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 
 skip_missing_interpreters = True
 


### PR DESCRIPTION
- updated year (docs, license)
- dropped Python 3.6 (docs, classifiers, tests)
- updated `pytest-responsemock` (py 3.6 drop related)


Sidenotes:
After we're done with this and #78, I hope we can run `black` on the whole rep :) 
And maybe switch to poetry \ pipenv for dependency locking and stuff...