### PR TITLE
Fix tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.torrent binary

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,15 +10,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Install locale
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt install libxslt-dev libxml2-dev locales -y && sudo locale-gen ru_RU.UTF-8
         sudo update-locale
@@ -33,6 +35,7 @@ jobs:
         uv sync --only-group tests
         uv pip install coveralls
     - uses: astral-sh/ruff-action@v3
+      if: matrix.os == 'ubuntu-latest'
       with:
         version: 0.13.1
         args: check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "beautifulsoup4",
     "torrentool",
     "lxml",
+    "dateparser",
 ]
 
 [project.urls]

--- a/src/torrt/base_tracker.py
+++ b/src/torrt/base_tracker.py
@@ -429,7 +429,7 @@ class GenericPublicTracker(GenericTracker):
     login_required: bool = False
 
     def get_id_from_link(self, url: str) -> str:
-        return url.split('/')[-1]
+        return url.rsplit('/', maxsplit=1)[-1]
 
     def download_torrent(self, url: str, *, referer: str = '') -> bytes | None:
         self.log_debug(f'Downloading torrent file from {url} ...')

--- a/src/torrt/trackers/kinozal.py
+++ b/src/torrt/trackers/kinozal.py
@@ -1,5 +1,7 @@
-from datetime import datetime, time, timedelta
+from datetime import datetime
 from typing import ClassVar
+
+import dateparser
 
 from ..base_tracker import GenericPrivateTracker
 
@@ -25,23 +27,8 @@ class KinozalTracker(GenericPrivateTracker):
         def refresh_in_text(tag):
             return tag.name == 'li' and tag.get_text().startswith('Обновлен')
 
-        def parse_date(date_val):
-            if date_val == 'сегодня':
-                return datetime.today()  # noqa: DTZ002
-
-            elif date_val == 'вчера':
-                return datetime.today() - timedelta(days=1)  # noqa: DTZ002
-
-            else:
-                return self.parse_datetime(date_val, '%d %B %Y', locale='ru')
-
         dt_val = getattr(self._torrent_page.find(refresh_in_text).find('span'), 'text', '').strip()
-        parts = dt_val.partition(' в ')
-        if len(parts) != 3:
-            return None
-        else:
-            time_val = time.fromisoformat(parts[2])
-            return parse_date(parts[0]).replace(hour=time_val.hour, minute=time_val.minute, second=0, microsecond=0)
+        return dateparser.parse(dt_val, languages=['ru'])
 
     def get_download_link(self, url: str) -> str:
         """Tries to find .torrent file download link at forum thread page and return that one."""

--- a/tests/trackers/test_eniahd.py
+++ b/tests/trackers/test_eniahd.py
@@ -9,7 +9,7 @@ def test_get_torrent(response_mock, datafix_read, datafix_dir):
     test_torrent = (datafix_dir / 'test.torrent').read_bytes()
 
     with response_mock([
-        f"GET https://eniatv.com/viewtopic.php?t=1558 -> 200: {datafix_read('eniahd.html')}",
+        f"GET https://eniatv.com/viewtopic.php?t=1558 -> 200: {datafix_read('eniahd.html', encoding='utf-8')}",
         b"GET https://eniatv.com/dl.php?id=5669 -> 200:" + test_torrent,
 
     ]) as _:

--- a/tests/trackers/test_nnmclub.py
+++ b/tests/trackers/test_nnmclub.py
@@ -11,7 +11,7 @@ def test_get_torrent(response_mock, datafix_read, datafix_dir):
     test_torrent = (datafix_dir / 'test.torrent').read_bytes()
 
     with response_mock([
-        f"GET https://nnmclub.to/forum/viewtopic.php?t=889443&sid= -> 200: {datafix_read('nnmclub.html')}",
+        f"GET https://nnmclub.to/forum/viewtopic.php?t=889443&sid= -> 200: {datafix_read('nnmclub.html', encoding='utf-8')}",
         b"GET https://nnmclub.to/forum/download.php?id=762672&sid= -> 200:" + test_torrent,
 
     ]) as _:

--- a/tests/trackers/test_nnmclub.py
+++ b/tests/trackers/test_nnmclub.py
@@ -9,9 +9,10 @@ def test_get_torrent(response_mock, datafix_read, datafix_dir):
     tracker.raise_on_error_response = True
 
     test_torrent = (datafix_dir / 'test.torrent').read_bytes()
+    page_html = datafix_read('nnmclub.html', encoding='utf-8')
 
     with response_mock([
-        f"GET https://nnmclub.to/forum/viewtopic.php?t=889443&sid= -> 200: {datafix_read('nnmclub.html', encoding='utf-8')}",
+        f"GET https://nnmclub.to/forum/viewtopic.php?t=889443&sid= -> 200: {page_html}",
         b"GET https://nnmclub.to/forum/download.php?id=762672&sid= -> 200:" + test_torrent,
 
     ]) as _:


### PR DESCRIPTION
`kinozal` date parsing couldn't parse strings like `16   мая 2015 в 18:00` on Windows. Windows `ru` locale only recognizes the nominative month form (`май`), but pages use the genitive form (`мая`)