### PR TITLE
qBittorrent: preserve torrent category on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # torrt changelog
 
+### Unreleased
+* ** qBittorrent: preserve torrent category on update.
+
 ### v1.1.0 [2026-03-30]
 * !! QA. Dropped QA for Py 3.7, 3.8, 3.9, 3.10.
 * ++ Add support to pass custom RPC parameters.

--- a/src/torrt/rpc/qbittorrent.py
+++ b/src/torrt/rpc/qbittorrent.py
@@ -158,11 +158,18 @@ class QBittorrentRPC(BaseRPC):
                 )
                 self.normalize_field_names(addition_data)
 
+                torrent_params: dict = {}
+
+                category = torrent_data.get('category')
+                if category:
+                    torrent_params['category'] = category
+
                 torrents_info.append({
                     'hash': torrent_data_hash,
                     'name': torrent_data['name'],
                     'download_to': torrent_data['download_to'],
-                    'comment': addition_data['comment']
+                    'comment': addition_data['comment'],
+                    'params': torrent_params,
                 })
 
         return torrents_info

--- a/tests/rpc/test_qbittorrent.py
+++ b/tests/rpc/test_qbittorrent.py
@@ -13,7 +13,8 @@ def test_get_torrents(response_mock, qbit, torrent_params):
 
     with response_mock([
             f'POST {qbit.url}auth/login -> 200:Ok.',
-            f'GET {qbit.url}torrents/info -> 200:' + '[{"hash": "xxxxx", "name": "mytorr", "save_path": "/home/idle"}]',
+            f'GET {qbit.url}torrents/info -> 200:'
+            '[{"hash": "xxxxx", "name": "mytorr", "save_path": "/home/idle", "category": "tv"}]',
             f'POST {qbit.url}torrents/properties -> 200:' + '{"comment": "somecomment"}',
         ],
         bypass=False
@@ -24,6 +25,27 @@ def test_get_torrents(response_mock, qbit, torrent_params):
             'name': 'mytorr',
             'hash': 'xxxxx',
             'download_to': '/home/idle',
+            'params': {'category': 'tv'},
+        }]
+
+
+def test_get_torrents_no_category(response_mock, qbit, torrent_params):
+
+    with response_mock([
+            f'POST {qbit.url}auth/login -> 200:Ok.',
+            f'GET {qbit.url}torrents/info -> 200:'
+            '[{"hash": "xxxxx", "name": "mytorr", "save_path": "/home/idle", "category": ""}]',
+            f'POST {qbit.url}torrents/properties -> 200:' + '{"comment": "somecomment"}',
+        ],
+        bypass=False
+    ):
+        response = qbit.method_get_torrents(hashes=['xxxxx'])
+        assert response == [{
+            'comment': 'somecomment',
+            'name': 'mytorr',
+            'hash': 'xxxxx',
+            'download_to': '/home/idle',
+            'params': {},
         }]
 
 


### PR DESCRIPTION
Read `category` in `method_get_torrents` and forward it via `params` so it is preserved on update