### PR TITLE
fix save settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # torrt changelog
 
 ### Unreleased
+* ** fix save settings.
 * ** qBittorrent: preserve torrent category on update.
 
 ### v1.1.0 [2026-03-30]

--- a/src/torrt/utils.py
+++ b/src/torrt/utils.py
@@ -589,9 +589,8 @@ class WithSettings:
         settings = {}
 
         try:
-            settings_names = getfullargspec(self.__init__)[0]
-
-            del settings_names[0]  # do not need `self`
+            spec = getfullargspec(self.__init__)
+            settings_names = spec.args[1:] + spec.kwonlyargs  # skip 'self', add kw-only
 
             for name in settings_names:
                 settings[name] = getattr(self, name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import torrt.utils as utils
+from torrt.trackers.rutracker import RuTrackerTracker
 
 
 def test_base64encode_str():
@@ -15,3 +16,14 @@ def test_base64encode_bytes():
 
     assert isinstance(encoded_bytes, bytes)
     assert encoded_bytes == b'dGhpcyBpcyBieXRlcyB0byBlbmNvZGU=\n'
+
+
+def test_save_settings(mock_config):
+    RuTrackerTracker(username='user', password='pass', query_string='qs').save_settings()
+
+    assert mock_config['trackers']['rutracker.org'] == {
+        'username': 'user',
+        'password': 'pass',
+        'cookies': {},
+        'query_string': 'qs',
+    }


### PR DESCRIPTION
 `WithSettings.save_settings` introspects `__init__` to discover setting names,
  but only looked at `getfullargspec(...).args`. After https://github.com/idlesign/torrt/commit/dcfb4547cd1c3146f77b03f068695d6639f8a694#diff-b78b80c1401f36ffbc9ab4e51d9bdc3e6c5cec943c3031f2eb3788d35f368bbaR463   `GenericPrivateTracker` migrated
 to keyword-only signatures, so the saved settings dict was always `{}`

Fix: include `spec.kwonlyargs` alongside `spec.args[1:]`
 
 before
 
<img width="277" height="80" alt="before" src="https://github.com/user-attachments/assets/f521869e-6f73-4e2d-8a53-0177745ae5ef" />

after
<img width="530" height="228" alt="after" src="https://github.com/user-attachments/assets/c4fbf5a5-517b-4d2d-aabd-4efe44aef461" />

